### PR TITLE
Add JIRA_ISSUES_URL_PATH config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ echo "https://jira.atlassian.com" >> .jira-url
 * `$JIRA_RAPID_BOARD` - Set to `true` if you use Rapid Board
 * `$JIRA_DEFAULT_ACTION` - Action to do when `jira` is called with no arguments; defaults to `git`
 * `$JIRA_BRANCH_REGEX` — Extended regular expression (ERE) for recognizing an issue code in a Git branch name; defaults to `s/.+\-([A-Z0-9]+-[0-9]+)\-.+/\1/p`
+* `$JIRA_ISSUES_URL_PATH` - The path to use in issue urls (defaults to `/browse/`)
 
 ### Git branch recognition ###
 

--- a/jira.plugin.zsh
+++ b/jira.plugin.zsh
@@ -54,6 +54,7 @@ function jira() {
     echo "JIRA_RAPID_BOARD=$JIRA_RAPID_BOARD"
     echo "JIRA_DEFAULT_ACTION=$JIRA_DEFAULT_ACTION"
     echo "JIRA_BRANCH_REGEX=$JIRA_BRANCH_REGEX"
+    echo "JIRA_ISSUES_URL_PATH=$JIRA_ISSUES_URL_PATH"
   else
     # Anything that doesn't match a special action is considered an issue name
     local issue_arg=$action
@@ -127,8 +128,8 @@ function _jira_open_issue() {
     url_fragment="#add-comment"
   fi
 
-  if [[ "$JIRA_RAPID_BOARD" == "true" ]]; then
-    local url="${jira_url}/issues/"
+  if [[ ! -z "$JIRA_ISSUES_URL_PATH" ]]; then
+    local url="${jira_url}${JIRA_ISSUES_URL_PATH}"
   else
     local url="${jira_url}/browse/"
   fi


### PR DESCRIPTION
Replaces this PR: https://github.com/igoradamenko/jira.plugin.zsh/pull/3

Adds a `$JIRA_ISSUES_URL_PATH` config variable for specifying the first part of the path for issue URLs. If not set, we use `/browse/` by default.  

This decouples the JIRA_RAPID_BOARD option from the issue url. 👍 